### PR TITLE
MurmerString() optimizations

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -1,8 +1,6 @@
 package hyperloglog
 
-import (
-	"encoding/binary"
-)
+import "unsafe"
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -14,17 +12,14 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := make([]byte, len(key))
-	copy(bkey[:], key)
-
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
 	l := blen / 4 // chunk length
-	tail := bkey[l*4:]
 
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -37,7 +32,8 @@ func MurmurString(key string) uint32 {
 
 	k = 0
 	// remainder
-	switch len(tail) {
+	tail := bkey[l*4:]
+	switch blen % 4 {
 	case 3:
 		k ^= uint32(tail[2]) << 16
 		fallthrough

--- a/murmur.go
+++ b/murmur.go
@@ -14,9 +14,10 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
-	blen := len(bkey)
+	bkey := make([]byte, len(key))
+	copy(bkey[:], key)
 
+	blen := len(bkey)
 	l := blen / 4 // chunk length
 	tail := bkey[l*4:]
 

--- a/murmur.go
+++ b/murmur.go
@@ -16,12 +16,9 @@ func MurmurString(key string) uint32 {
 	blen := len(bkey)
 	l := blen / 4 // chunk length
 
-	// for each 4 byte chunk of `key'
+	// encode each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		// next 4 byte chunk of `key'
 		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
-
-		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -31,21 +28,23 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	// remainder
-	tail := bkey[l*4:]
-	switch blen % 4 {
-	case 3:
-		k ^= uint32(tail[2]) << 16
-		fallthrough
-	case 2:
-		k ^= uint32(tail[1]) << 8
-		fallthrough
-	case 1:
-		k ^= uint32(tail[0])
-		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
-		k *= c2
-		h ^= k
+	//remainder
+	if mod := blen % 4; mod > 0 {
+		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
+		switch mod {
+		case 3:
+			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			fallthrough
+		case 2:
+			k ^= ((btail >> 8) & 0x000000FF) << 8
+			fallthrough
+		case 1:
+			k ^= btail & 0x000000FF
+			k *= c1
+			k = (k << 15) | (k >> (32 - 15))
+			k *= c2
+			h ^= k
+		}
 	}
 
 	h ^= uint32(blen)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -46,8 +47,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 100; i++ {
-		key := randString((i % 15) + 5)
+	for i := 0; i < 1000; i++ {
+		key := randString((i % 199) + 1)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }


### PR DESCRIPTION
Some optimizations to speed up MurmerString()
- Use unsafe class to convert string -> []byte (huge speedup)
- Use bitwise operations where we can (not a huge performance boost, but shaves off a couple hundred nanoseconds)

Also benchmarks.