### PR TITLE
fix: make murmur hash deterministic

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -33,7 +33,7 @@ func MurmurString(key string) uint32 {
 		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
 		switch mod {
 		case 3:
-			k ^= ((btail >> 16) & 0x0000FFFF) << 16
+			k ^= ((btail >> 16) & 0x000000FF) << 16
 			fallthrough
 		case 2:
 			k ^= ((btail >> 8) & 0x000000FF) << 8


### PR DESCRIPTION
@flapjack103 @jmoiron 

On strings where string length is `3 mod 4` for example : **PUxDjsdapVrYdwI** the hash was not deterministic, because the mask is `0x0000FFFF` instead of `0x000000FF`.

As this code uses `unsafe.Pointer` this would return a random area of memory in addition to the 32 bytes needed, making **k** different if this random area of memory does not contain zero.

Running the tests ~1000 times, it fails a dozen of time !
