### PR TITLE
Revert PR that had multiple memory safety bugs.

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,8 @@
 package hyperloglog
 
-import "unsafe"
+import (
+	"encoding/binary"
+)
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
 // for little endian machines only with no heap allocation.  If you are using
@@ -12,13 +14,18 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
+	bkey := []byte(key)
 	blen := len(bkey)
-	l := blen / 4 // chunk length
 
-	// encode each 4 byte chunk of `key'
+	l := blen / 4 // chunk length
+	tail := bkey[l*4:]
+
+	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
-		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
+		// next 4 byte chunk of `key'
+		k = binary.LittleEndian.Uint32(bkey[i*4:])
+
+		// encode next 4 byte chunk of `key'
 		k *= c1
 		k = (k << 15) | (k >> (32 - 15))
 		k *= c2
@@ -28,23 +35,20 @@ func MurmurString(key string) uint32 {
 	}
 
 	k = 0
-	//remainder
-	if mod := blen % 4; mod > 0 {
-		btail := *(*uint32)(unsafe.Pointer(&bkey[l*4]))
-		switch mod {
-		case 3:
-			k ^= ((btail >> 16) & 0x000000FF) << 16
-			fallthrough
-		case 2:
-			k ^= ((btail >> 8) & 0x000000FF) << 8
-			fallthrough
-		case 1:
-			k ^= btail & 0x000000FF
-			k *= c1
-			k = (k << 15) | (k >> (32 - 15))
-			k *= c2
-			h ^= k
-		}
+	// remainder
+	switch len(tail) {
+	case 3:
+		k ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k ^= uint32(tail[0])
+		k *= c1
+		k = (k << 15) | (k >> (32 - 15))
+		k *= c2
+		h ^= k
 	}
 
 	h ^= uint32(blen)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -47,8 +46,8 @@ func TestMurmur(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 1000; i++ {
-		key := randString((i % 199) + 1)
+	for i := 0; i < 100; i++ {
+		key := randString((i % 15) + 5)
 		hash := mmh3.Hash32([]byte(key))
 		m := MurmurString(key)
 		if hash != m {
@@ -64,57 +63,4 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
-}
-
-// Benchmarks
-func benchmarkMurmer64(b *testing.B, input []uint64) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			Murmur64(x)
-		}
-	}
-}
-
-func benchmarkMurmerString(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			MurmurString(x)
-		}
-	}
-}
-
-func benchmarkHash32(b *testing.B, input []string) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, x := range input {
-			b := *(*[]byte)(unsafe.Pointer(&x))
-			mmh3.Hash32(b)
-		}
-	}
-}
-
-func Benchmark100Murmer64(b *testing.B) {
-	input := make([]uint64, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = uint64(rand.Int63())
-	}
-	benchmarkMurmer64(b, input)
-}
-
-func Benchmark100MurmerString(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkMurmerString(b, input)
-}
-
-func Benchmark100Hash32(b *testing.B) {
-	input := make([]string, 100)
-	for i := 0; i < 100; i++ {
-		input[i] = randString((i % 15) + 5)
-	}
-	benchmarkHash32(b, input)
 }


### PR DESCRIPTION
This reverts commit a0d95f8e223241dec63d5681ae0f3597dd8b09cb, reversing
changes made to b0c692f7450b0f8fb612a568f9382defb27c115e.

The PR has two memory safety bugs. The bug that caused crashes in production was in line:

https://github.com/DataDog/hyperloglog/pull/2/files#diff-ba13805dd99130b4d69363bddcbae2fdR33

That line is reading four bytes from a buffer that is less than four bytes long, which is a buffer overflow. The buffer overflow caused segfaults in production.

The second memory bug is this cast:

https://github.com/DataDog/hyperloglog/pull/2/files#diff-ba13805dd99130b4d69363bddcbae2fdR15

I'm not sure of the validity of the cast (though, `reflect.StringHeader` seems to be the sanctioned way to do this), but the GC is allowed to deallocate `key` any time it chooses after that line since `key` is not used again. A call to `runtime.KeepAlive` is needed to prevent the GC from doing so.