### PR TITLE
Use reflect.StringHeader to avoid the copy from `string` -> `[]byte`

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -27,7 +27,13 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	// Reinterpret
+	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
+	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
+	//    break that assumption.
+	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
+	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
+	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
+	//    is used as a no-op use.
 	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&key))
 	blen := strHeader.Len
 

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }


### PR DESCRIPTION
As best as I am aware, this change is safe for now. I've added a comment with a number of caveats.

On my machine, I saw the following numbers:

Before:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4   	 1000000	      1798 ns/op	       0 B/op	       0 allocs/op

After:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4   	 2000000	       863 ns/op	       0 B/op	       0 allocs/op