### PR TITLE
Restore safe casts and benchmarks from #2

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -1,8 +1,6 @@
 package hyperloglog
 
 import (
-	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -16,15 +14,8 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
-	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
-	//    break that assumption.
-	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
-	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
-	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
-	//    is used as a no-op use.
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
-	bkey := *(*[]byte)(unsafe.Pointer(sh))
+	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
 
 	l := blen / 4 // chunk length
@@ -67,8 +58,6 @@ func MurmurString(key string) uint32 {
 	h ^= (h >> 13)
 	h *= 0xc2b2ae35
 	h ^= (h >> 16)
-
-	runtime.KeepAlive(&key)
 
 	return h
 }

--- a/murmur.go
+++ b/murmur.go
@@ -1,7 +1,9 @@
 package hyperloglog
 
 import (
-	"encoding/binary"
+	"reflect"
+	"runtime"
+	"unsafe"
 )
 
 // This file implements the murmur3 32-bit hash on 32bit and 64bit integers
@@ -14,7 +16,15 @@ func MurmurString(key string) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	bkey := []byte(key)
+	// Reinterpret the string as a `StringHeader`. This comes with three important caveats:
+	// 1. We must never write through the pointer derived. Golang strings are immutable and we cannot
+	//    break that assumption.
+	// 2. Golang continues to have a non-moving GC. This only works because the Golang GC is
+	//    (currently) non-moving. There are no plans to break this yet, but it remains a caveat.
+	// 3. `key` is used after the `StringHeader` is no longer needed. Currently, `runtime.KeepAlive`
+	//    is used as a no-op use.
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bkey := *(*[]byte)(unsafe.Pointer(sh))
 	blen := len(bkey)
 
 	l := blen / 4 // chunk length
@@ -23,7 +33,7 @@ func MurmurString(key string) uint32 {
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = binary.LittleEndian.Uint32(bkey[i*4:])
+		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
 
 		// encode next 4 byte chunk of `key'
 		k *= c1
@@ -57,6 +67,9 @@ func MurmurString(key string) uint32 {
 	h ^= (h >> 13)
 	h *= 0xc2b2ae35
 	h ^= (h >> 16)
+
+	runtime.KeepAlive(&key)
+
 	return h
 }
 

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/mmh3"
 )
@@ -63,4 +64,57 @@ func randString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// Benchmarks
+func benchmarkMurmer64(b *testing.B, input []uint64) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			Murmur64(x)
+		}
+	}
+}
+
+func benchmarkMurmerString(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurString(x)
+		}
+	}
+}
+
+func benchmarkHash32(b *testing.B, input []string) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			b := *(*[]byte)(unsafe.Pointer(&x))
+			mmh3.Hash32(b)
+		}
+	}
+}
+
+func Benchmark100Murmer64(b *testing.B) {
+	input := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = uint64(rand.Int63())
+	}
+	benchmarkMurmer64(b, input)
+}
+
+func Benchmark100MurmerString(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkMurmerString(b, input)
+}
+
+func Benchmark100Hash32(b *testing.B) {
+	input := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		input[i] = randString((i % 15) + 5)
+	}
+	benchmarkHash32(b, input)
 }


### PR DESCRIPTION
The first cast saves a call to `runtime.stringtoslicebyte` which takes about 400 ns/op. The second cast converts the four bytes with about half the number of instructions, which saves about 100 ns/op. I've spent a bunch of time staring at the following documents, and I *think* this is safe (for our current platform and current version of Go).

https://golang.org/pkg/unsafe/#Pointer
https://golang.org/pkg/reflect/#StringHeader

The go runtime could still break this in the future, but I've attempted to document that.

Before:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4 1000000	1798 ns/op	0 B/op	0 allocs/op

After:

goos: darwin
goarch: amd64
pkg: github.com/DataDog/hyperloglog
Benchmark100MurmerString-4 2000000 1207 ns/op	0 B/op	0 allocs/op