### PR TITLE
[murmur] Add MurmurBytes method to not have to cast to string

### DIFF
--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -84,6 +84,22 @@ func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
 }
 
+func TestMurmurBytes(t *testing.T) {
+	b := []byte("hello")
+	v := MurmurBytes(b)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
+	}
+}
+
+func TestMurmurString(t *testing.T) {
+	s := "hello"
+	v := MurmurString(s)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+	}
+}
+
 func benchmarkCount(b *testing.B, registers int) {
 	words := dictionary(0)
 	m := uint(math.Pow(2, float64(registers)))

--- a/murmur.go
+++ b/murmur.go
@@ -11,13 +11,18 @@ import (
 // MurmurString implements a fast version of the murmur hash function for strings
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
+	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
+	bkey := *(*[]byte)(unsafe.Pointer(&key))
+	return MurmurBytes(bkey)
+}
+
+// MurmurBytes implements a fast version of the murmur hash function for bytes
+// for little endian machines.  Suitable for adding strings to HLL counter.
+func MurmurBytes(bkey []byte) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
 	var h, k uint32
 
-	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
 	blen := len(bkey)
-
 	l := blen / 4 // chunk length
 	tail := bkey[l*4:]
 


### PR DESCRIPTION
Just add `MurmurBytes` method to not have to unsafe from `[]byte` -> `string` -> `[]byte`