### PR TITLE
[murmur] Fix MurmurBytes

### DIFF
--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -84,22 +84,6 @@ func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
 }
 
-func TestMurmurBytes(t *testing.T) {
-	b := []byte("hello")
-	v := MurmurBytes(b)
-	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
-	}
-}
-
-func TestMurmurString(t *testing.T) {
-	s := "hello"
-	v := MurmurString(s)
-	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
-	}
-}
-
 func benchmarkCount(b *testing.B, registers int) {
 	words := dictionary(0)
 	m := uint(math.Pow(2, float64(registers)))

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,7 @@
 package hyperloglog
 
 import (
+	"reflect"
 	"unsafe"
 )
 
@@ -12,8 +13,13 @@ import (
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
 	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	bkey := *(*[]byte)(unsafe.Pointer(&key))
-	return MurmurBytes(bkey)
+	b := make([]byte, 0)
+	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sHeader := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bHeader.Data = sHeader.Data
+	bHeader.Len = sHeader.Len
+	bHeader.Cap = sHeader.Len
+	return MurmurBytes(b)
 }
 
 // MurmurBytes implements a fast version of the murmur hash function for bytes

--- a/murmur.go
+++ b/murmur.go
@@ -1,6 +1,7 @@
 package hyperloglog
 
 import (
+	"math"
 	"reflect"
 	"unsafe"
 )
@@ -13,13 +14,9 @@ import (
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurString(key string) uint32 {
 	// Reinterpret the string as bytes. This is safe because we don't write into the byte array.
-	b := make([]byte, 0)
-	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sHeader := (*reflect.StringHeader)(unsafe.Pointer(&key))
-	bHeader.Data = sHeader.Data
-	bHeader.Len = sHeader.Len
-	bHeader.Cap = sHeader.Len
-	return MurmurBytes(b)
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	byteSlice := (*[math.MaxInt32 - 1]byte)(unsafe.Pointer(sh.Data))[:sh.Len:sh.Len]
+	return MurmurBytes(byteSlice)
 }
 
 // MurmurBytes implements a fast version of the murmur hash function for bytes

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -57,6 +57,22 @@ func TestMurmur(t *testing.T) {
 	}
 }
 
+func TestMurmurBytes(t *testing.T) {
+	b := []byte("hello")
+	v := MurmurBytes(b)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", b, v, 613153351)
+	}
+}
+
+func TestMurmurString(t *testing.T) {
+	s := "hello"
+	v := MurmurString(s)
+	if v != 613153351 {
+		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+	}
+}
+
 func randString(n int) string {
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -69,7 +69,7 @@ func TestMurmurString(t *testing.T) {
 	s := "hello"
 	v := MurmurString(s)
 	if v != 613153351 {
-		t.Fatalf("MurmurBytes failed for %s: %v != %v", s, v, 613153351)
+		t.Fatalf("MurmurString failed for %s: %v != %v", s, v, 613153351)
 	}
 }
 
@@ -83,7 +83,7 @@ func randString(n int) string {
 }
 
 // Benchmarks
-func benchmarkMurmer64(b *testing.B, input []uint64) {
+func benchmarkMurmur64(b *testing.B, input []uint64) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, x := range input {
@@ -92,7 +92,7 @@ func benchmarkMurmer64(b *testing.B, input []uint64) {
 	}
 }
 
-func benchmarkMurmerString(b *testing.B, input []string) {
+func benchmarkMurmurString(b *testing.B, input []string) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for _, x := range input {
@@ -111,20 +111,20 @@ func benchmarkHash32(b *testing.B, input []string) {
 	}
 }
 
-func Benchmark100Murmer64(b *testing.B) {
+func Benchmark100Murmur64(b *testing.B) {
 	input := make([]uint64, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = uint64(rand.Int63())
 	}
-	benchmarkMurmer64(b, input)
+	benchmarkMurmur64(b, input)
 }
 
-func Benchmark100MurmerString(b *testing.B) {
+func Benchmark100MurmurString(b *testing.B) {
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)
 	}
-	benchmarkMurmerString(b, input)
+	benchmarkMurmurString(b, input)
 }
 
 func Benchmark100Hash32(b *testing.B) {

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/mmh3"
+	"github.com/dustin/randbo"
 )
 
 var buf32 = make([]byte, 4)
@@ -133,4 +134,19 @@ func Benchmark100Hash32(b *testing.B) {
 		input[i] = randString((i % 15) + 5)
 	}
 	benchmarkHash32(b, input)
+}
+
+func BenchmarkMurmurStringBig(b *testing.B) {
+	// Make a 100Mb string and use that as a benchmark
+	r := randbo.New()
+	slice := make([]byte, 100*1024*1024)
+	_, err := r.Read(slice)
+	if err != nil {
+		b.Fatalf("Failed to create benchmark data: %s", err)
+	}
+	s := string(slice)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MurmurString(s)
+	}
 }


### PR DESCRIPTION
The current MurmurBytes has a wrong implementation because given the same parameter it could return 2 different values.
Consider this simple program:
```go
package main

import (
    "fmt"
    "github.com/DataDog/hyperloglog"
)

func main() {
    var s1 string = "hello"
    fmt.Println(hyperloglog.MurmurString(s1))
    fmt.Println(hyperloglog.MurmurString(s1))
}
```

The output is different.
This is because currently we unsafe convert a string to a slice.
Unfortunatly the SliceHeader & StringHeader are different: https://golang.org/pkg/reflect/#SliceHeader

```go
type SliceHeader struct {
        Data uintptr
        Len  int
        Cap  int
}
type StringHeader struct {
        Data uintptr
        Len  int
}
```

So when converting `StringHeader` to `SliceHeader` `Data` & `Len` are the same place but `Cap` will
be completly garbage (whatever byte is after)

What happened is when `Data="hello", Len=5, Cap=0`, doing a slice `data[4:]` will actually return `h` and not `o`.
This is probably because Cap < Len (which should never happen).
Unfortunatly we cannot edit the `SliceHeader.Cap` without creating at least another Header object otherwise we
would edit memory data of another thing.
So we need at the minimum to create a `SliceHeader`, that's what we do here.

Since potentially (UTF-8), I would say len(string) != len(bytes), I would actually be partial to just eat it up
and do the copy like before.

Here are the benchmarks:

Current (incorrect) behavior vs creating a `SliceHeader`:
```
name               old time/op  new time/op  delta
100MurmerString-4  1.04µs ± 3%  1.37µs ± 3%  +31.44%  (p=0.000 n=10+9)
```

So it's ~30% slower

Current behavior vs copy:
```
name               old time/op  new time/op  delta
100MurmerString-4  1.04µs ± 3%  1.84µs ± 2%  +76.47%  (p=0.000 n=10+10)
```

So almost 2x slower

We need the `SlicerHeader` anyway so doing a copy instead is:
```
name               old time/op  new time/op  delta
100MurmerString-4  1.37µs ± 3%  1.84µs ± 2%  +34.25%  (p=0.000 n=9+10)
```

~35% slower so I'd still be of the opinion to just eat it up and do the copy