### PR TITLE
Avoid extra allocations in calls to Reset()

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -60,7 +60,7 @@ func New(registers uint) (*HyperLogLog, error) {
 	h.M = registers
 	h.B = uint32(math.Ceil(math.Log2(float64(registers))))
 	h.Alpha = getAlpha(registers)
-	h.Reset()
+	h.Registers = make([]uint8, h.M)
 	return h, nil
 }
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -66,7 +66,9 @@ func New(registers uint) (*HyperLogLog, error) {
 
 // Reset all internal variables and set the count to zero.
 func (h *HyperLogLog) Reset() {
-	h.Registers = make([]uint8, h.M)
+	for i := range h.Registers {
+		h.Registers[i] = 0
+	}
 }
 
 // Calculate the position of the leftmost 1-bit.

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -97,10 +97,16 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 		for j := 0; j < numObjects; j++ {
 			h.Add(rand.Uint32())
 		}
-		h.Reset()
 
-		if h.Count() != 0 {
-			t.Errorf("reset failed, count=%d", h.Count())
+		oldRegisters := &h.Registers
+		h.Reset()
+		if oldRegisters != &h.Registers {
+			t.Error("registers were reallocated")
+		}
+		for _, r := range h.Registers {
+			if r != 0 {
+				t.Error("register is not zeroed out after reset")
+			}
 		}
 	}
 }

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"io"
 	"math"
+	"math/rand"
 	"os"
 	"testing"
 )
@@ -82,6 +83,30 @@ func TestHyperLogLogSmall(t *testing.T) {
 
 func TestHyperLogLogBig(t *testing.T) {
 	testHyperLogLog(t, 0, 4, 17)
+}
+
+func testReset(t *testing.T, m uint, numObjects, runs int) {
+	rand.Seed(101)
+
+	h, err := New(m)
+	if err != nil {
+		t.Fatalf("can't make New(%d): %v", m, err)
+	}
+
+	for i := 0; i < runs; i++ {
+		for j := 0; j < numObjects; j++ {
+			h.Add(rand.Uint32())
+		}
+		h.Reset()
+
+		if h.Count() != 0 {
+			t.Errorf("reset failed, count=%d", h.Count())
+		}
+	}
+}
+
+func TestReset(t *testing.T) {
+	testReset(t, 512, 1_000_000, 10)
 }
 
 func benchmarkCount(b *testing.B, registers int) {

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -124,6 +124,8 @@ func BenchmarkReset(b *testing.B) {
 		b.Fatalf("can't make New(%d): %v", m, err)
 	}
 
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < numObjects; i++ {
 			h.Add(uint32(i))

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -111,26 +111,25 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 	}
 }
 
-func benchmarkReset(b *testing.B, h *HyperLogLog, numObjects int) {
+func TestReset(t *testing.T) {
+	testReset(t, 512, 1_000_000, 10)
+}
+
+func BenchmarkReset(b *testing.B) {
+	m := uint(256)
+	numObjects := 1000
+
+	h, err := New(m)
+	if err != nil {
+		b.Fatalf("can't make New(%d): %v", m, err)
+	}
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < numObjects; i++ {
 			h.Add(uint32(i))
 		}
 		h.Reset()
 	}
-}
-
-func TestReset(t *testing.T) {
-	testReset(t, 512, 1_000_000, 10)
-}
-
-func BenchmarkReset(b *testing.B) {
-	h, err := New(256)
-	if err != nil {
-		b.Fatalf("can't make New(256): %v", err)
-	}
-
-	benchmarkReset(b, h, 1000)
 }
 
 func benchmarkCount(b *testing.B, registers int) {

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -111,8 +111,26 @@ func testReset(t *testing.T, m uint, numObjects, runs int) {
 	}
 }
 
+func benchmarkReset(b *testing.B, h *HyperLogLog, numObjects int) {
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < numObjects; i++ {
+			h.Add(uint32(i))
+		}
+		h.Reset()
+	}
+}
+
 func TestReset(t *testing.T) {
 	testReset(t, 512, 1_000_000, 10)
+}
+
+func BenchmarkReset(b *testing.B) {
+	h, err := New(256)
+	if err != nil {
+		b.Fatalf("can't make New(256): %v", err)
+	}
+
+	benchmarkReset(b, h, 1000)
 }
 
 func benchmarkCount(b *testing.B, registers int) {


### PR DESCRIPTION
During an investigation of performance of onne of our services, we noticed a large amount of CPU spent on calls to `Reset`. Looking at the code, we determined that the `Reset` function allocates new memory for each of the registers every time it's called. This PR aims to change that behavior by simply zeroing out each register instead of reallocating them