### PR TITLE
Update murmurbytes and benchmarks

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -35,7 +35,8 @@ func MurmurBytes(bkey []byte) uint32 {
 	// for each 4 byte chunk of `key'
 	for i := 0; i < l; i++ {
 		// next 4 byte chunk of `key'
-		k = *(*uint32)(unsafe.Pointer(&bkey[i*4]))
+		data := bkey[i*4 : (i*4)+4]
+		k := uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
 
 		// encode next 4 byte chunk of `key'
 		k *= c1

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -83,6 +83,7 @@ func TestMurmurStringZero(t *testing.T) {
 }
 
 func randString(n int) string {
+	rand.Seed(10)
 	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]rune, n)
 	for i := range b {
@@ -92,6 +93,15 @@ func randString(n int) string {
 }
 
 // Benchmarks
+func benchmarkMurmurBytes(b *testing.B, input [][]byte) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, x := range input {
+			MurmurBytes(x)
+		}
+	}
+}
+
 func benchmarkMurmur64(b *testing.B, input []uint64) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -120,7 +130,19 @@ func benchmarkHash32(b *testing.B, input []string) {
 	}
 }
 
+func Benchmark100MurmurBytes(b *testing.B) {
+	rand.Seed(10)
+	input := make([][]byte, 100)
+	for i := 0; i < 100; i++ {
+		x := make([]byte, 1000)
+		rand.Read(x)
+		input[i] = x
+	}
+	benchmarkMurmurBytes(b, input)
+}
+
 func Benchmark100Murmur64(b *testing.B) {
+	rand.Seed(10)
 	input := make([]uint64, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = uint64(rand.Int63())
@@ -129,6 +151,7 @@ func Benchmark100Murmur64(b *testing.B) {
 }
 
 func Benchmark100MurmurString(b *testing.B) {
+	rand.Seed(10)
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)
@@ -137,6 +160,7 @@ func Benchmark100MurmurString(b *testing.B) {
 }
 
 func Benchmark100Hash32(b *testing.B) {
+	rand.Seed(10)
 	input := make([]string, 100)
 	for i := 0; i < 100; i++ {
 		input[i] = randString((i % 15) + 5)


### PR DESCRIPTION
This PR removes calls to `unsafe.Pointer` from `MurmuBytes` in order to be compatible with [go 1.14](https://golang.org/doc/go1.14#compiler). It also adds benchmark tests for this function. Results of running the new tests added in this PR against master using `go test -bench=Murmur`:

```
$ benchcmp old new
benchmark                      old ns/op     new ns/op     delta
Benchmark100MurmurBytes-8      28618         33227         +16.11%
Benchmark100Murmur64-8         347           367           +5.76%
Benchmark100MurmurString-8     833           928           +11.40%
BenchmarkMurmurStringBig-8     30933217      37862688      +22.40%
```

As we can see, this change adds significant overhead to the functions that call `MurmurBytes`. (The Murmur64 benchmark can likely be safely ignored, since this PR does not touch its functionality).