### PR TITLE
Fix unsafe pointer usage in MurmurBytes

### DIFF
--- a/murmur.go
+++ b/murmur.go
@@ -2,6 +2,7 @@ package hyperloglog
 
 import (
 	"math"
+	"math/bits"
 	"reflect"
 	"unsafe"
 )
@@ -26,50 +27,48 @@ func MurmurString(key string) uint32 {
 // for little endian machines.  Suitable for adding strings to HLL counter.
 func MurmurBytes(bkey []byte) uint32 {
 	var c1, c2 uint32 = 0xcc9e2d51, 0x1b873593
-	var h, k uint32
+	var h uint32
 
 	blen := len(bkey)
-	l := blen / 4 // chunk length
-	tail := bkey[l*4:]
+	chunks := blen / 4 // chunk length
 
-	// for each 4 byte chunk of `key'
-	for i := 0; i < l; i++ {
-		// next 4 byte chunk of `key'
-		data := bkey[i*4 : (i*4)+4]
-		k := uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
+	values := (*(*[]uint32)(unsafe.Pointer(&bkey)))[:chunks:chunks]
 
-		// encode next 4 byte chunk of `key'
+	for _, k := range values {
 		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
+		k = bits.RotateLeft32(k, 15)
 		k *= c2
+
 		h ^= k
-		h = (h << 13) | (h >> (32 - 13))
+		h = bits.RotateLeft32(h, 13)
 		h = (h * 5) + 0xe6546b64
 	}
 
-	k = 0
+	var k uint32
+	tailLength := blen % 4
+	tailStart := blen - tailLength
 	// remainder
-	switch len(tail) {
+	switch tailLength {
 	case 3:
-		k ^= uint32(tail[2]) << 16
+		k ^= uint32(bkey[tailStart+2]) << 16
 		fallthrough
 	case 2:
-		k ^= uint32(tail[1]) << 8
+		k ^= uint32(bkey[tailStart+1]) << 8
 		fallthrough
 	case 1:
-		k ^= uint32(tail[0])
+		k ^= uint32(bkey[tailStart])
 		k *= c1
-		k = (k << 15) | (k >> (32 - 15))
+		k = bits.RotateLeft32(k, 15)
 		k *= c2
 		h ^= k
 	}
 
 	h ^= uint32(blen)
-	h ^= (h >> 16)
+	h ^= h >> 16
 	h *= 0x85ebca6b
-	h ^= (h >> 13)
+	h ^= h >> 13
 	h *= 0xc2b2ae35
-	h ^= (h >> 16)
+	h ^= h >> 16
 
 	return h
 }


### PR DESCRIPTION
This commit updates MurmurBytes to read the input data as a block of []uint32 rather than one uint32 at a time.  This allows us to signal to the compiler that the data is aligned in a way that doesn't fail the checkptr check.

This commit also swaps in `bits.RotateLeft32` instead of the handrolled version as it is equally fast and there is no need to duplicate stdlib

Profiling revealed that creating the `tail` slice was actually a source of some CPU usage so this commit also removes that and instead calculates the length of the tail and the index where it starts.

I ran the benchmarks 50 times and saved the results as `original.txt` and then I ran the new code 50 times, twice:

```
$ benchstat original.txt new.txt
name               old time/op  new time/op  delta
100MurmurBytes-2   29.6µs ± 4%  29.0µs ± 3%   -2.03%  (p=0.000 n=46+46)
100Murmur64-2       372ns ± 3%   384ns ± 2%   +3.39%  (p=0.000 n=49+50)
100MurmurString-2   924ns ±16%   829ns ± 3%  -10.18%  (p=0.000 n=49+48)
MurmurStringBig-2  33.6ms ± 9%  30.8ms ±10%   -8.27%  (p=0.000 n=45+49)

$ benchstat original.txt new1.txt
name               old time/op  new time/op  delta
100MurmurBytes-2   29.6µs ± 4%  29.7µs ± 9%    ~     (p=0.567 n=46+45)
100Murmur64-2       372ns ± 3%   400ns ± 5%  +7.49%  (p=0.000 n=49+44)
100MurmurString-2   924ns ±16%   923ns ± 5%  -0.07%  (p=0.017 n=49+49)
MurmurStringBig-2  33.6ms ± 9%  33.3ms ± 4%    ~     (p=0.153 n=45+49)
```

The benchmarks vary but these indicate that the new code is at least as fast as the original if not slightly faster