### PR TITLE
[hyperloglog] Improve HLL performance

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -54,6 +54,9 @@ func getAlpha(m uint) (result float64) {
 // The estimates provided by hyperloglog are expected to be within σ, 2σ, 3σ
 // of the exact count in respectively 65%, 95%, 99% of all the cases.
 func New(registers uint) (*HyperLogLog, error) {
+	if registers == 0 {
+		panic("cannot have zero registers")
+	}
 	if (registers & (registers - 1)) != 0 {
 		return nil, fmt.Errorf("number of registers %d not a power of two", registers)
 	}
@@ -76,7 +79,7 @@ func (h *HyperLogLog) Reset() {
 // good hash function.
 func (h *HyperLogLog) Add(val uint32) {
 	k := 32 - h.B
-	slice := val<<h.B | 1<<(h.B-1)
+	slice := (val << h.B) | (1 << (h.B - 1))
 	r := uint8(bits.LeadingZeros32(slice) + 1)
 	j := val >> uint(k)
 	if r > h.Registers[j] {

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -11,10 +11,11 @@ package hyperloglog
 import (
 	"fmt"
 	"math"
+	"math/bits"
 )
 
-var (
-	exp32 = math.Pow(2, 32)
+const (
+	exp32 = 1 << 32 // 2^32
 )
 
 // A HyperLogLog is a deterministic cardinality estimator.  This version
@@ -58,7 +59,7 @@ func New(registers uint) (*HyperLogLog, error) {
 	}
 	h := &HyperLogLog{}
 	h.M = registers
-	h.B = uint32(math.Ceil(math.Log2(float64(registers))))
+	h.B = uint32(math.Log2(float64(registers)))
 	h.Alpha = getAlpha(registers)
 	h.Registers = make([]uint8, h.M)
 	return h, nil
@@ -71,21 +72,12 @@ func (h *HyperLogLog) Reset() {
 	}
 }
 
-// Calculate the position of the leftmost 1-bit.
-func rho(val uint32, max uint32) uint8 {
-	r := uint32(1)
-	for val&0x80000000 == 0 && r <= max {
-		r++
-		val <<= 1
-	}
-	return uint8(r)
-}
-
 // Add to the count. val should be a 32 bit unsigned integer from a
 // good hash function.
 func (h *HyperLogLog) Add(val uint32) {
 	k := 32 - h.B
-	r := rho(val<<h.B, k)
+	slice := val<<h.B | 1<<(h.B-1)
+	r := uint8(bits.LeadingZeros32(slice) + 1)
 	j := val >> uint(k)
 	if r > h.Registers[j] {
 		h.Registers[j] = r
@@ -110,7 +102,7 @@ func (h *HyperLogLog) count(withLargeRangeCorrection bool) uint64 {
 	sum := 0.0
 	m := float64(h.M)
 	for _, val := range h.Registers {
-		sum += 1.0 / math.Pow(2.0, float64(val))
+		sum += 1.0 / float64(int(1)<<val)
 	}
 	estimate := h.Alpha * m * m / sum
 	if estimate <= 5.0/2.0*m {


### PR DESCRIPTION
What does this PR do?
---------------------
Replaces `rho()` with the stdlib `bits.LeadingZeros32()`, which is intrinsified on amd64 and arm64 and accomplishes the same task (counting the number of leading zeroes in the bit representation of a value) with improved performance. 

Replaces a few calls to the `math` library with bit manipulation, which is less performance intensive

Additional Notes
----------------
Benchmarks indicate significant performance improvements compared to the previous version of HLL (run on an arm64 M1 macbook): 
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkReset-10               6405          1356          -78.83%
BenchmarkCount4-10              222           10.2          -95.41%
BenchmarkCount5-10              490           20.4          -95.85%
BenchmarkCount6-10              915           45.8          -94.99%
BenchmarkCount7-10              2143          95.5          -95.55%
BenchmarkCount8-10              4740          215           -95.47%
BenchmarkCount9-10              10890         459           -95.78%
BenchmarkCount10-10             23733         958           -95.96%
Benchmark100MurmurBytes-10      43042         42812         -0.53%
Benchmark100Murmur64-10         256           257           +0.43%
Benchmark100MurmurString-10     629           629           -0.02%
Benchmark100Hash32-10           690           691           +0.17%
BenchmarkMurmurStringBig-10     46412977      46652778      +0.52%
```
Benchmarks prior to this PR: 
```
BenchmarkReset-10              	  156872	      6405 ns/op
BenchmarkCount4-10             	 5422813	       222.4 ns/op
BenchmarkCount5-10             	 2498756	       490.3 ns/op
BenchmarkCount6-10             	 1299194	       915.0 ns/op
BenchmarkCount7-10             	  546396	      2143 ns/op
BenchmarkCount8-10             	  246973	      4740 ns/op
BenchmarkCount9-10             	  109562	     10890 ns/op
BenchmarkCount10-10            	   50743	     23733 ns/op
Benchmark100MurmurBytes-10     	   28096	     43042 ns/op
Benchmark100Murmur64-10        	 4674187	       255.8 ns/op
Benchmark100MurmurString-10    	 1897222	       629.3 ns/op
Benchmark100Hash32-10          	 1743304	       689.8 ns/op
BenchmarkMurmurStringBig-10    	      25	  46412977 ns/op
```
Benchmarks after this PR's changes:
```
BenchmarkReset-10              	  879480	      1356 ns/op
BenchmarkCount4-10             	100000000	        10.21 ns/op
BenchmarkCount5-10             	57705370	        20.36 ns/op
BenchmarkCount6-10             	26007872	        45.84 ns/op
BenchmarkCount7-10             	12631954	        95.46 ns/op
BenchmarkCount8-10             	 5594330	       214.9 ns/op
BenchmarkCount9-10             	 2608581	       459.3 ns/op
BenchmarkCount10-10            	 1259529	       957.8 ns/op
Benchmark100MurmurBytes-10     	   28106	     42812 ns/op
Benchmark100Murmur64-10        	 4693041	       256.9 ns/op
Benchmark100MurmurString-10    	 1902806	       629.2 ns/op
Benchmark100Hash32-10          	 1741650	       691.0 ns/op
BenchmarkMurmurStringBig-10    	      25	  46652778 ns/op
```