### PR TITLE
Optimise merge operation

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -135,12 +135,12 @@ func (h *HyperLogLog) Merge(other *HyperLogLog) error {
 	}
 
 	// Trigger boundary check once for h.Registers
-	thisRegister := h.Registers
-	_ = thisRegister[len(other.Registers)-1]
+	registers := h.Registers
+	_ = registers[len(other.Registers)-1]
 
 	for j, r := range other.Registers {
-		if r > thisRegister[j] {
-			thisRegister[j] = r
+		if r > registers[j] {
+			registers[j] = r
 		}
 	}
 	return nil

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -133,9 +133,14 @@ func (h *HyperLogLog) Merge(other *HyperLogLog) error {
 		return fmt.Errorf("number of registers doesn't match: %d != %d",
 			h.M, other.M)
 	}
+
+	// Trigger boundary check once for h.Registers
+	thisRegister := h.Registers
+	_ = thisRegister[len(other.Registers)-1]
+
 	for j, r := range other.Registers {
-		if r > h.Registers[j] {
-			h.Registers[j] = r
+		if r > thisRegister[j] {
+			thisRegister[j] = r
 		}
 	}
 	return nil


### PR DESCRIPTION
It is possible to get ride of boundary check in the Merge operation


```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/hyperloglog
         │   old.txt   │               new.txt               │
         │   sec/op    │   sec/op     vs base                │
Merge-10   977.3n ± 1%   661.1n ± 1%  -32.35% (p=0.000 n=12)

         │  old.txt   │            new.txt             │
         │    B/op    │    B/op     vs base            │
Merge-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=12) ¹
¹ all samples are equal

         │  old.txt   │            new.txt             │
         │ allocs/op  │ allocs/op   vs base            │
Merge-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=12) ¹
```